### PR TITLE
Fix for 'Fatal error: Cannot use static when no class scope is active'

### DIFF
--- a/govdelivery.module
+++ b/govdelivery.module
@@ -38,7 +38,7 @@ function govdelivery_trusted_host() {
   $request = \Drupal::request();
   $host_patterns = $request->getTrustedHosts();
   if (PHP_SAPI !== 'cli' && !empty($host_patterns)) {
-    if (static::setupTrustedHosts($request, $host_patterns) === FALSE) {
+    if (DrupalKernel::setupTrustedHosts($request, $host_patterns) === FALSE) {
       return FALSE;
     }
   }


### PR DESCRIPTION
When enabling the TMS module, I get "Fatal error: Cannot use “static” when no class scope is active in /srv/bindings/80635c66fa28493ca50a78e5f19a564d/code/modules/govdelivery/govdelivery.module on line 41." This pull request should fix the class scope issue.